### PR TITLE
pulls chrom. lengths from the same source as for the bigwig files.

### DIFF
--- a/BSseq_pipeline.py
+++ b/BSseq_pipeline.py
@@ -566,12 +566,14 @@ rule final_report:
         rules.bam_methCall.output,
         rules.methseg.output,
         lambda wc: finalReportDiffMeth_input(wc.prefix),
-        template      = os.path.join(DIR_templates,"index.Rmd")
+        template      = os.path.join(DIR_templates,"index.Rmd"),
+        chrom_seqlengths    = DIR_mapped+"Refgen_"+ASSEMBLY+"_chromlengths.csv"
     output: 
         report        = os.path.join(DIR_final, "{prefix}.sorted_{assembly}_final.html")
     params:
         ## absolute path to bamfiles
         Samplename  = lambda wc: get_fastq_name( wc.prefix ),
+        chrom_seqlengths  = DIR_mapped+"Refgen_"+ASSEMBLY+"_chromlengths.csv",
         source_dir  = config['locations']['input-dir'],
         out_dir     = config['locations']['output-dir'],
         inBam       = os.path.join(DIR_sorted,"{prefix}.sorted.bam"),

--- a/BSseq_pipeline.py
+++ b/BSseq_pipeline.py
@@ -567,13 +567,13 @@ rule final_report:
         rules.methseg.output,
         lambda wc: finalReportDiffMeth_input(wc.prefix),
         template      = os.path.join(DIR_templates,"index.Rmd"),
-        chrom_seqlengths    = DIR_mapped+"Refgen_"+ASSEMBLY+"_chromlengths.csv"
+        chrom_seqlengths    = os.path.join(DIR_mapped,"Refgen_"+ASSEMBLY+"_chromlengths.csv")
     output: 
         report        = os.path.join(DIR_final, "{prefix}.sorted_{assembly}_final.html")
     params:
         ## absolute path to bamfiles
         Samplename  = lambda wc: get_fastq_name( wc.prefix ),
-        chrom_seqlengths  = DIR_mapped+"Refgen_"+ASSEMBLY+"_chromlengths.csv",
+        chrom_seqlengths  = os.path.join(DIR_mapped,"Refgen_"+ASSEMBLY+"_chromlengths.csv"),
         source_dir  = config['locations']['input-dir'],
         out_dir     = config['locations']['output-dir'],
         inBam       = os.path.join(DIR_sorted,"{prefix}.sorted.bam"),

--- a/configure.ac
+++ b/configure.ac
@@ -55,7 +55,6 @@ AC_ARG_ENABLE([r-packages-check],
   [AC_MSG_NOTICE([Skipping R packages check.  Be careful!])],
   [dnl
 AX_R_PACKAGE([genomation])
-AX_R_PACKAGE([GenomeInfoDb])
 AX_R_PACKAGE([methylKit], [1.3.3])
 AX_R_PACKAGE([AnnotationHub])
 AX_R_PACKAGE([DT])

--- a/guix.scm
+++ b/guix.scm
@@ -136,7 +136,6 @@ The main functions of FastQC are:
        ("r-annotationhub" ,r-annotationhub)
        ("r-dt" ,r-dt)
        ("r-genomation" ,r-genomation)
-       ("r-genomeinfodb" ,r-genomeinfodb)
        ("r-methylkit" ,r-methylkit)
        ("r-rtracklayer" ,r-rtracklayer)
        ("r-rmarkdown" ,r-rmarkdown)

--- a/report_templates/index.Rmd.in
+++ b/report_templates/index.Rmd.in
@@ -559,8 +559,6 @@ cat('## Annotation of Differentially Methylated Cytosines\n')
     library("rtracklayer")
     library("DT")
     library("ggplot2")
-    library("GenomeInfoDb")
-
 ```
 
 ```{r AnnotateDiffMeth.print_params_in, results='asis', eval=AnnotateDiffMeth}

--- a/report_templates/index.Rmd.in
+++ b/report_templates/index.Rmd.in
@@ -16,6 +16,7 @@ link-citations: yes
 params:
   MethCall: TRUE
   Samplename: ''
+  chrom_seqlengths: ''
   source_dir: ''
   out_dir:    ''
   inBam:    ''
@@ -734,14 +735,12 @@ cat('### Overview of Hyper- and Hypo-Methylated CpGs Over the Genome\n')
 
 if(length(GRanges.diffmeth.hypo)>1 & length(GRanges.diffmeth.hyper)>1){
 
-require(GenomeInfoDb)
-chr.len.df=fetchExtendedChromInfoFromUCSC(assembly,
-        goldenPath_url="http://hgdownload.cse.ucsc.edu/goldenPath",
-        quiet=FALSE)
-chr.len=chr.len.df[,2]
-names(chr.len)=chr.len.df[,1]
 
-myseqinfo = Seqinfo(chr.len.df[,1], seqlengths=chr.len.df[,2], genome=assembly)
+seqdat_temp    = read.csv(chrom_seqlengths, sep="\t", header=FALSE)
+chr.len        = seqdat_temp[,2]
+names(chr.len) = seqdat_temp[,1]
+
+myseqinfo = Seqinfo(seqdat_temp[,1], seqlengths=seqdat_temp[,2], genome=assembly)
 myseqinfo.st = keepStandardChromosomes(myseqinfo)
 
 source(paste0(params$scripts_dir, "ideoDMC.R"))


### PR DESCRIPTION
Address issue #73 --tested, and produces report successfully. Still need to confirm whether this is the only instance of unwanted internet-fetching (but this does certainly eliminate at least one).