### PR TITLE
Cluster q direct

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,8 +286,10 @@ execution:
 | nice                  | integer: From -20 to 19; higher values make the program execution less demanding on computational resources
 | cluster:memory        | string: Amount of memory used for all jobs besides bismark, e.g. "8G"
 | cluster:stack         | string: Stack size limit (used for cluster jobs), e.g. "128m"
-| cluster:queue         | string: Queue name (used for cluster jobs), e.g. "all"
+| cluster:queue**       | string: Queue name (used for cluster jobs), e.g. "all.q"
 | cluster:contact-email | string: Email address where information about pipelines progress is sent (if it is running on a cluster).
+
+** - Most users will submit a single queue name to the settings file, and all rules will be executed on that queue. Advanced users may wish to submit different rules to different queues; this can be performed by omitting the field `cluster:queue` from the settings files, and directly editing the default values (per-rule) in `etc/settings.yaml.in` under `execution:rules`.
 
 ### Tools
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,10 @@ The figure below provides a schematic of the process.
 # Install
 
 PiGx BSseq uses the GNU build system.  If you want to install PiGx BSseq from
-source (here you can find the [latest release here](https://github.com/BIMSBbioinfo/pigx_bsseq/releases/latest)), please make sure that all required dependencies are installed and then follow these steps after unpacking the latest release tarball:
+source (here you can find the [latest release
+here](https://github.com/BIMSBbioinfo/pigx_bsseq/releases/latest)), please make
+sure that all required dependencies are installed and then follow these steps
+after unpacking the latest release tarball:
 
 ```sh
 ./configure --prefix=/some/where
@@ -73,11 +76,10 @@ configuration time.
 
 You can install PiGx BSseq through Guix (TODO: add details here after release).
 
-Run the `configure` script to probe your environment for tools needed
-by the pipeline.  Rather than installing  all packages manually, we 
-generally recommend using [GNU Guix](https://gnu.org/s/guix).  The
-following command spawns a sub-shell in which all dependencies are
-available:
+Run the `configure` script to probe your environment for tools needed by the
+pipeline.  Rather than installing  all packages manually, we generally
+recommend using [GNU Guix](https://gnu.org/s/guix).  The following command
+spawns a sub-shell in which all dependencies are available:
 
 ```sh
 guix environment -l guix.scm
@@ -138,10 +140,9 @@ This pipeline was developed by the Akalin group at MDC in Berlin in 2017-2018.
 
 # Input Parameters
 
-The pipeline expects two kinds of input: a sample sheet in CSV format
-and a settings file specifying the desired behaviour of PiGx BSseq.
-PiGx BSseq will automatically generate a JSON configuration file from
-these inputs.
+The pipeline expects two kinds of input: a sample sheet in CSV format and a
+settings file specifying the desired behaviour of PiGx BSseq.  PiGx BSseq will
+automatically generate a JSON configuration file from these inputs.
 
 ## Sample Sheet
 
@@ -275,21 +276,48 @@ execution:
   cluster:
     memory: 8G
     stack: 128M
-    queue: all
+    queue: all.q
     contact-email: none
 ```
 
 | Variable name         | description |
 | --------------------- |:-----------:|
-| submit-to-cluster     | string: Whether the pipeline should run locally ("no") or on a cluster with an SGE queueing system.
+| submit-to-cluster     | string: Whether the pipeline should run locally ("no") or on a cluster with an SGE queueing system ("yes").
 | jobs                  | string: Number of jobs sent to cluster, e.g. "6"
 | nice                  | integer: From -20 to 19; higher values make the program execution less demanding on computational resources
 | cluster:memory        | string: Amount of memory used for all jobs besides bismark, e.g. "8G"
 | cluster:stack         | string: Stack size limit (used for cluster jobs), e.g. "128m"
-| cluster:queue**       | string: Queue name (used for cluster jobs), e.g. "all.q"
 | cluster:contact-email | string: Email address where information about pipelines progress is sent (if it is running on a cluster).
 
-** - Most users will submit a single queue name to the settings file, and all rules will be executed on that queue. Advanced users may wish to submit different rules to different queues; this can be performed by omitting the field `cluster:queue` from the settings files, and directly editing the default values (per-rule) in `etc/settings.yaml.in` under `execution:rules`.
+
+Further values can be supplied. For example, should the user wish to allocate
+job submission onto a specific queue (which we will call **X**) for  _all_
+rules being executed, they may set:
+
+```
+execution:
+  ...
+  cluster:
+    queue:  X
+  ...
+...
+```
+
+Or certain rules can be allocated to specific queues as follows:
+
+```
+execution:
+  ...
+  rules:
+    __default__:
+      queue: X
+    bismark_align_and_map_se:
+      queue: Y
+    ...
+...
+```
+In the latter case, the `__default__` rule must be defined, and there may not
+be any multiply-defined variables.
 
 ### Tools
 
@@ -320,9 +348,7 @@ during execution, however, the underlying process based on snakemake will
 produce further updates to screen showing the status of the run. Within each
 subfolder, further programs will generate their own log files that can be
 consulted in case debugging is necessary (e.g. if a run fails with a cryptic
-error message, and the output directory contains folders named `01\_\*`, 
-`02\_\*`,  `03\_\*`, etc., we recommend reading the last few lines of the 
-`\*.log` files in the last directory to be created.)
-
- 
+error message, and the output directory contains folders named `01_*`, 
+`02_*`,  `03_*`, etc., we recommend reading the last few lines of the 
+`*.log` files in the last directory to be created.)
 

--- a/etc/settings.yaml.in
+++ b/etc/settings.yaml.in
@@ -30,15 +30,12 @@ execution:
     __default__:
       threads: 1
       memory: 8G
-      queue: all.q
     bismark_align_and_map_se:
       threads: 6
       memory: 19G
-      queue: all.q
     bismark_align_and_map_pe:
       threads: 12
       memory: 19G
-      queue: all.q
 
 tools:
   fastqc:

--- a/etc/settings.yaml.in
+++ b/etc/settings.yaml.in
@@ -25,18 +25,20 @@ execution:
     missing-file-timeout: 120
     memory: 8G
     stack: 128M
-    queue: all
     contact-email: none
   rules:
     __default__:
       threads: 1
       memory: 8G
+      queue: all.q
     bismark_align_and_map_se:
       threads: 6
       memory: 19G
+      queue: all.q
     bismark_align_and_map_pe:
       threads: 12
       memory: 19G
+      queue: all.q
 
 tools:
   fastqc:

--- a/pigx-bsseq.in
+++ b/pigx-bsseq.in
@@ -264,18 +264,31 @@ def generate_cluster_configuration():
     cluster_conf = {}
     for rule in rules:
         if 'queue' in config['execution']['cluster']:
-            qval = config['execution']['cluster']['queue'] 
-            # most users will submit a single queue name to the settings file
-            # over-writing the defaults & submitting all rules to the same queue.
+            # --- User has supplied general queue name for all rules---
+            if 'queue' in rules[rule]:
+              bail("ERROR: 'queue' multiply defined in settings file.") #AND per rule ->error
+            else:
+              cluster_conf[rule] = {
+              'nthreads': rules[rule]['threads'],
+              'MEM':      rules[rule]['memory'],
+              'queue':    config['execution']['cluster']['queue'],
+              'h_stack':  config['execution']['cluster']['stack']
+              }
+        elif ( 'queue' in rules[rule] ):
+              # --- User has supplied a queue for this specific rule.
+              cluster_conf[rule] = {
+              'nthreads': rules[rule]['threads'],
+              'MEM':      rules[rule]['memory'],
+              'queue':    rules[rule]['queue'],
+              'h_stack':  config['execution']['cluster']['stack']
+              }
         else:
-            qval = rules[rule]['queue'] # advanced users can set rule-based queues in the defaults
-
-        cluster_conf[rule] = {
-            'nthreads': rules[rule]['threads'],
-            'MEM':      rules[rule]['memory'],
-            'q':        qval,
-            'h_stack': config['execution']['cluster']['stack']
-        }
+              # --- User has provided no information on queue for this rule -> default.
+              cluster_conf[rule] = {
+              'nthreads': rules[rule]['threads'],
+              'MEM':      rules[rule]['memory'],
+              'h_stack':  config['execution']['cluster']['stack']
+              }
 
     cluster_config_file = "cluster_conf.json"
     with open(cluster_config_file, 'w') as outfile:
@@ -397,6 +410,18 @@ command = [
 if config['execution']['submit-to-cluster']:
     cluster_config_file = generate_cluster_configuration()
     print("Commencing snakemake run submission to cluster", flush=True, file=sys.stderr)
+
+    if ( ('queue' in config['execution']['cluster'] )  or ( 'queue' in config['execution']['rules']['__default__'] )):
+        queue_selection_string = " -q {cluster.queue} "
+	# User has defined queue name(s) --either generally, or rule-specific.
+	# in either case, generate_cluster_configuration() (defined above) has 
+        # already printed thk apropriate queue name to each rule.
+        queue_selection_string = " -q {cluster.queue} "
+    else :
+        # User has supplied no q value -> let SGE pick the the default.
+        queue_selection_string = ""
+    # --- done checking if ( queue name(s) supplied by user)
+
     if config['execution']['cluster']['contact-email'].lower() == 'none':
         contact_email_string = ""
     else:
@@ -410,7 +435,7 @@ if config['execution']['submit-to-cluster']:
             exit(1)
         else:
             raise
-    qsub = "qsub -V -q {cluster.q} -l h_stack={cluster.h_stack} -l h_vmem={cluster.MEM} %s -b y -pe smp {cluster.nthreads} -cwd" % contact_email_string
+    qsub = "qsub -V  %s -l h_stack={cluster.h_stack} -l h_vmem={cluster.MEM} %s -b y -pe smp {cluster.nthreads} -cwd" % ( queue_selection_string, contact_email_string)
     command += [
         "--cluster-config={}".format(cluster_config_file),
         "--cluster={}".format(qsub),

--- a/pigx-bsseq.in
+++ b/pigx-bsseq.in
@@ -265,10 +265,14 @@ def generate_cluster_configuration():
     for rule in rules:
         cluster_conf[rule] = {
             'nthreads': rules[rule]['threads'],
-            'q': config['execution']['cluster']['queue'],
-            'MEM': rules[rule]['memory'],
+            'MEM':      rules[rule]['memory'],
+            'q':        rules[rule]['queue'], # advanced users can set rule-based queues in the defaults
             'h_stack': config['execution']['cluster']['stack']
         }
+        if 'queue' in config['execution']['cluster']:
+            cluster_conf[rule]['q'] = config['execution']['cluster']['queue'],
+	    # most users will submit a single queue name to the settings file
+	    # over-writing the defaults & submitting all rules to the same queue.
 
     cluster_config_file = "cluster_conf.json"
     with open(cluster_config_file, 'w') as outfile:

--- a/pigx-bsseq.in
+++ b/pigx-bsseq.in
@@ -403,7 +403,7 @@ if config['execution']['submit-to-cluster']:
             exit(1)
         else:
             raise
-    qsub = "qsub -V -l h_stack={cluster.h_stack}  -l h_vmem={cluster.MEM} %s -b y -pe smp {cluster.nthreads} -cwd" % contact_email_string
+    qsub = "qsub -V -q {cluster.q} -l h_stack={cluster.h_stack} -l h_vmem={cluster.MEM} %s -b y -pe smp {cluster.nthreads} -cwd" % contact_email_string
     command += [
         "--cluster-config={}".format(cluster_config_file),
         "--cluster={}".format(qsub),

--- a/pigx-bsseq.in
+++ b/pigx-bsseq.in
@@ -263,16 +263,19 @@ def generate_cluster_configuration():
 
     cluster_conf = {}
     for rule in rules:
+        if 'queue' in config['execution']['cluster']:
+            qval = config['execution']['cluster']['queue'] 
+            # most users will submit a single queue name to the settings file
+            # over-writing the defaults & submitting all rules to the same queue.
+        else:
+            qval = rules[rule]['queue'] # advanced users can set rule-based queues in the defaults
+
         cluster_conf[rule] = {
             'nthreads': rules[rule]['threads'],
             'MEM':      rules[rule]['memory'],
-            'q':        rules[rule]['queue'], # advanced users can set rule-based queues in the defaults
+            'q':        qval,
             'h_stack': config['execution']['cluster']['stack']
         }
-        if 'queue' in config['execution']['cluster']:
-            cluster_conf[rule]['q'] = config['execution']['cluster']['queue'],
-	    # most users will submit a single queue name to the settings file
-	    # over-writing the defaults & submitting all rules to the same queue.
 
     cluster_config_file = "cluster_conf.json"
     with open(cluster_config_file, 'w') as outfile:

--- a/test/settings.yaml
+++ b/test/settings.yaml
@@ -25,5 +25,5 @@ execution:
   cluster:
     memory: 8G
     stack: 128M
-    queue: all
+    queue: all.q
     contact-email: none


### PR DESCRIPTION
Allows advanced users to go into the default settings and submit rules to different queues; this is kept hidden from most users who will usually just want to submit everything to the same queue