### PR TITLE
Add verbose and shell-command options to argument list

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ optional arguments:
                                           fresh.
   --reason                                Print the reason why a rule is executed.
   --unlock                                Recover after a snakemake crash.
+  --verbose                               Print supplementary info on job execution.
+  --printshellcmds                        Explicitly print commands being executed by snakemake to standard out.
+
+
 
 This pipeline was developed by the Akalin group at MDC in Berlin in 2017-2018.
 ```

--- a/pigx-bsseq.in
+++ b/pigx-bsseq.in
@@ -110,6 +110,15 @@ parser.add_argument('--unlock', dest='unlock', action='store_true',
                     help="""\
 Recover after a snakemake crash.""")
 
+parser.add_argument('--verbose', dest='verbose', action='store_true',
+                    help="""\
+Print supp info on job execution.""")
+
+parser.add_argument('--printshellcmds', dest='printshellcmds', action='store_true',
+                    help="""\
+Print commands being executed by snakemake.""")
+
+
 args = parser.parse_args()
 
 
@@ -465,6 +474,10 @@ else:
         command.append("--reason")
     if args.unlock:
         command.append("--unlock")
+    if args.verbose:
+        command.append("--verbose")
+    if args.printshellcmds:
+        command.append("--printshellcmds")
     if args.target == 'help':
         command.append("help")
     subprocess.run(command)

--- a/pigx-bsseq.in
+++ b/pigx-bsseq.in
@@ -112,7 +112,7 @@ Recover after a snakemake crash.""")
 
 parser.add_argument('--verbose', dest='verbose', action='store_true',
                     help="""\
-Print supp info on job execution.""")
+Print supplementary info on job execution.""")
 
 parser.add_argument('--printshellcmds', dest='printshellcmds', action='store_true',
                     help="""\


### PR DESCRIPTION
Added two arguments to the list of commands ( they were useful during debugging and might be useful as well for trouble-shooting)

@rekado , I just added these by analogy to the entries you'd already put in there. If you're ok with this, then I'll just merge with master