### PR TITLE
Dedupe patch

### DIFF
--- a/report_templates/diffmeth.Rmd.in
+++ b/report_templates/diffmeth.Rmd.in
@@ -1,7 +1,7 @@
 ---
 title: "PiGx: BS-seq"
-output: 
-  html_notebook: 
+output:
+  html_notebook:
     toc:        TRUE
     toc_float:  TRUE
     theme:      "lumen"
@@ -103,12 +103,12 @@ treatmentpair = params$treatment
 assembly = params$assembly
 
 outputdir = paste(params$out_dir, params$diffmeth_dir, sep="/")
-methylDiff_file        <- paste0(outputdir, treatmentpair,'.sorted_diffmeth.RDS')
-methylDiff_hyper_file  <- paste0(outputdir, treatmentpair,'.sorted_diffmethhyper.RDS')
-methylDiff_hypo_file   <- paste0(outputdir, treatmentpair,'.sorted_diffmethhypo.RDS')
-methylDiff_nonsig_file <- paste0(outputdir, treatmentpair,'.sorted_diffmethnonsig.RDS')
+methylDiff_file        <- paste0(outputdir, treatmentpair,'.deduped_diffmeth.RDS')
+methylDiff_hyper_file  <- paste0(outputdir, treatmentpair,'.deduped_diffmethhyper.RDS')
+methylDiff_hypo_file   <- paste0(outputdir, treatmentpair,'.deduped_diffmethhypo.RDS')
+methylDiff_nonsig_file <- paste0(outputdir, treatmentpair,'.deduped_diffmethnonsig.RDS')
 
-methylDiffBed          <- paste0(outputdir, treatmentpair,'.sorted_diffmeth.bed')
+methylDiffBed          <- paste0(outputdir, treatmentpair,'.deduped_diffmeth.bed')
 ```
 
 ```{r DiffMeth.load, eval=DiffMeth}
@@ -358,7 +358,7 @@ cat('### Overview of Hyper- and Hypo-Methylated CpGs Over the Genome\n')
 
 if(length(GRanges.diffmeth.hypo)>1 & length(GRanges.diffmeth.hyper)>1){
 
-seqdat_temp    = read.csv(paste0(out_dir,"/",chrom_seqlengths), 
+seqdat_temp    = read.csv(paste0(out_dir,"/",chrom_seqlengths),
                           sep="\t", header=FALSE, stringsAsFactors=FALSE)
 chr.len        = seqdat_temp[,2]
 names(chr.len) = seqdat_temp[,1]
@@ -375,8 +375,8 @@ ideoDMC_hyper_hypo(methylDiff.obj.hyper, methylDiff.obj.hypo, chrom.length = seq
 ```
 
 Below is a histogram of (statistically significant) differential CpG
-methylation, alongside CpG sites without statistically significant 
-differences in methylation --each are normalized independently, as the 
+methylation, alongside CpG sites without statistically significant
+differences in methylation --each are normalized independently, as the
 latter are generally far more numerous than the former).
 
 ```{r plot.methdiff.histogram, eval=AnnotateDiffMeth}

--- a/scripts/func_defs.py
+++ b/scripts/func_defs.py
@@ -97,14 +97,14 @@ def bigwig_exporting(files, sampleID):
         return  PATH+sampleID+"_se.bw" #---- single end
     elif len(files) == 2:
         return [PATH+sampleID+"_pe.bw"] #---- paired end
-        
+
 def methSeg(files, sampleID):
     PATH = DIR_seg
     if len(files) == 1:
         return  PATH+sampleID+"_se_bt2.sorted.deduped_meth_segments_gr.RDS" #---- single end
     elif len(files) == 2:
         return [PATH+sampleID+"_1_val_1_bt2.sorted.deduped_meth_segments_gr.RDS"] #---- paired end
-        
+
 def list_final_reports(files, sampleID):
     PATH = DIR_final
     if len(files) == 1:
@@ -129,7 +129,7 @@ def get_fastq_name(full_name):
     elif(find_pe_inx>=0):
      output=full_name[:find_pe_inx]
     else:
-     print("Sth went wrong")
+     print("Unable to infer Sample fastq name from Snakemake-generated string.")
 
     return(output)
 
@@ -148,17 +148,17 @@ def diff_meth_input(wc):
       name_of_dir = x[0]+"_"+x[1]+".sorted_"+wc.assembly+"_annotation.diff.meth.nb.html"
       mylist.append(DIR_annot + name_of_dir)
   return(mylist)
-  
+
 def finalReportDiffMeth_input(prefix):
   sampleid = get_fastq_name(prefix)
   sample_treatments_dict = dict(zip(SAMPLE_IDS, SAMPLE_TREATMENTS))
   treatment_of_sampleid = sample_treatments_dict[ sampleid ]
   treatments = ["_".join(pair) for pair in config["general"]["differential-methylation"]["treatment-groups"] if treatment_of_sampleid in pair]
   outList = []
-  if treatments: 
-      outList  = [ "{}{}.sorted_{}.RDS".format(DIR_diffmeth,treat,type) for type in ["diffmeth","diffmethhyper","diffmethhypo"] for treat in treatments]
-      outList += [ "{}{}.sorted_diffmeth.bed".format(DIR_diffmeth,treat,type) for treat in treatments ]
-  
+  if treatments:
+      outList  = [ "{}{}.deduped_{}.RDS".format(DIR_diffmeth,treat,type) for type in ["diffmeth","diffmethhyper","diffmethhypo"] for treat in treatments]
+      outList += [ "{}{}.deduped_diffmeth.bed".format(DIR_diffmeth,treat,type) for treat in treatments ]
+
   return  outList
 
 def get_sampleids_from_treatment(treatment):

--- a/scripts/func_defs.py
+++ b/scripts/func_defs.py
@@ -129,7 +129,7 @@ def get_fastq_name(full_name):
     elif(find_pe_inx>=0):
      output=full_name[:find_pe_inx]
     else:
-     print("Unable to infer Sample fastq name from Snakemake-generated string.")
+     bail("Unable to infer sample fastq name; cannot find trimming string in filename. \nHave the files been trimmed for adapter sequence and quality?")
 
     return(output)
 

--- a/scripts/func_defs.py
+++ b/scripts/func_defs.py
@@ -69,18 +69,18 @@ def list_files_bismark(files, sampleID):
 def list_files_dedupe(files, sampleID):
     PATH = DIR_deduped
     if len(files) == 1:
-        return [PATH+sampleID+"_se_bt2.deduped.bam"] #---- single end
+        return [PATH+sampleID+"_se_bt2.sorted.deduped.bam"] #---- single end
     elif len(files) == 2:
-        return [PATH+sampleID+"_1_val_1_bt2.deduped.bam"] #---- paired end
+        return [PATH+sampleID+"_1_val_1_bt2.sorted.deduped.bam"] #---- paired end
     else:
         raise Exception("=== ERROR: file list is neither 1 nor 2 in length. STOP! ===")
 
 def list_files_sortbam(files, sampleID):
     PATH = DIR_sorted
     if len(files) == 1:
-        return [PATH+sampleID+"_se_bt2.deduped.sorted.bam"] #---- single end
+        return [PATH+sampleID+"_se_bt2.sorted.bam"] #---- single end
     elif len(files) == 2:
-        return [PATH+sampleID+"_1_val_1_bt2.deduped.sorted.bam"] #---- paired end
+        return [PATH+sampleID+"_1_val_1_bt2.sorted.bam"] #---- paired end
     else:
         raise Exception("=== ERROR: file list is neither 1 nor 2 in length. STOP! ===")
 

--- a/scripts/func_defs.py
+++ b/scripts/func_defs.py
@@ -87,9 +87,9 @@ def list_files_sortbam(files, sampleID):
 def bam_processing(files, sampleID):
     PATH = DIR_methcall
     if len(files) == 1:
-        return  PATH+sampleID+"_se_bt2.deduped.sorted_methylRaw.RDS" #---- single end
+        return  PATH+sampleID+"_se_bt2.sorted.deduped_methylRaw.RDS" #---- single end
     elif len(files) == 2:
-        return [PATH+sampleID+"_1_val_1_bt2.deduped.sorted_methylRaw.RDS"] #---- paired end
+        return [PATH+sampleID+"_1_val_1_bt2.sorted.deduped_methylRaw.RDS"] #---- paired end
 
 def bigwig_exporting(files, sampleID):
     PATH = DIR_bigwig
@@ -101,16 +101,16 @@ def bigwig_exporting(files, sampleID):
 def methSeg(files, sampleID):
     PATH = DIR_seg
     if len(files) == 1:
-        return  PATH+sampleID+"_se_bt2.deduped.sorted_meth_segments_gr.RDS" #---- single end
+        return  PATH+sampleID+"_se_bt2.sorted.deduped_meth_segments_gr.RDS" #---- single end
     elif len(files) == 2:
-        return [PATH+sampleID+"_1_val_1_bt2.deduped.sorted_meth_segments_gr.RDS"] #---- paired end
+        return [PATH+sampleID+"_1_val_1_bt2.sorted.deduped_meth_segments_gr.RDS"] #---- paired end
         
 def list_final_reports(files, sampleID):
     PATH = DIR_final
     if len(files) == 1:
-        return  PATH+sampleID+"_se_bt2.deduped.sorted_"+ASSEMBLY+"_final.html" #---- single end
+        return  PATH+sampleID+"_se_bt2.sorted.deduped_"+ASSEMBLY+"_final.html" #---- single end
     elif len(files) == 2:
-        return [PATH+sampleID+"_1_val_1_bt2.deduped.sorted_"+ASSEMBLY+"_final.html"] #---- paired end
+        return [PATH+sampleID+"_1_val_1_bt2.sorted.deduped_"+ASSEMBLY+"_final.html"] #---- paired end
 
 
 
@@ -180,9 +180,9 @@ def diffmeth_input_function(wc):
   for sampleid in sampleids:
     fqname = config["SAMPLES"][sampleid]['fastq_name']
     if len(fqname)==1:
-      inputfile=[os.path.join(DIR_methcall,sampleid+"_se_bt2.deduped.sorted_methylRaw.RDS")]
+      inputfile=[os.path.join(DIR_methcall,sampleid+"_se_bt2.sorted.deduped_methylRaw.RDS")]
     elif len(fqname)==2:
-      inputfile=[os.path.join(DIR_methcall,sampleid+"_1_val_1_bt2.deduped.sorted_methylRaw.RDS")]
+      inputfile=[os.path.join(DIR_methcall,sampleid+"_1_val_1_bt2.sorted.deduped_methylRaw.RDS")]
     inputfiles.append(inputfile)
 
   inputfiles = list(sum(inputfiles, []))

--- a/test.sh.in
+++ b/test.sh.in
@@ -15,7 +15,7 @@ chmod -R +w ${srcdir}/tests
 ./pigx-bsseq -s ${srcdir}/tests/settings.yaml ${srcdir}/tests/sample_sheet.csv
 
 for base in PEsample_1_val_1_bt2 SEsample_se_bt2 SEsample_v2_se_bt2; do
-    if ! test -f "${srcdir}/tests/out/Final_Reports/${base}.deduped.sorted_hg19_final.html"
+    if ! test -f "${srcdir}/tests/out/Final_Reports/${base}.sorted.deduped_hg19_final.html"
     then
         echo "ERROR: could not find report for ${base}"
         exit 1


### PR DESCRIPTION
puts rules in hierarchical order
adds a fair amount of documentation
ensures that deduplication is being performed after sorting (as it needs to be)