### PR TITLE
clean/reports

### DIFF
--- a/etc/settings.yaml.in
+++ b/etc/settings.yaml.in
@@ -2,6 +2,11 @@ locations:
   input-dir: /path/to/reads/
   output-dir: /path/to/output/
   genome-fasta: /path/to/genome.fasta
+  # UCSC annotation tables fetched from table browser in BED format.
+  # CpG island predictions
+  cpgIsland-bedfile: ''
+  # Gene annotation, should be refGenes or knownGenes table
+  refGenes-bedfile: ''
 
 general:
   assembly: ''
@@ -36,11 +41,6 @@ general:
     cores: 1
     qvalue: 0.01
     difference: 25
-    annotation:
-      cpgIsland-bedfile: ''
-      refGenes-bedfile: ''
-      # download cpgIsland-bedfile or refGenes-bedfile automatically if not given?
-      webfetch:   no
       
 # DManalyses:
 #   # The names of analyses can be anything but they have to be unique

--- a/etc/settings.yaml.in
+++ b/etc/settings.yaml.in
@@ -3,9 +3,9 @@ locations:
   output-dir: /path/to/output/
   genome-fasta: /path/to/genome.fasta
   # UCSC annotation tables fetched from table browser in BED format.
-  # CpG island predictions
+  # [optional] CpG island predictions
   cpgIsland-bedfile: ''
-  # Gene annotation, should be refGenes or knownGenes table
+  # [optional] Gene annotation, should be refGenes or knownGenes table
   refGenes-bedfile: ''
 
 general:

--- a/report_templates/diffmeth.Rmd.in
+++ b/report_templates/diffmeth.Rmd.in
@@ -488,7 +488,7 @@ meth2bed(windows = methylDiff.obj.all,
          filename = bedFile) 
 ```
 
-```{r DiffMeth.find_dmr_text, results='asis', eval=ExtractDiffMeth}
+```{r DiffMeth.find_dmr_text, results='asis'}
 cat('## Finding Regions of Differential Methylation\n\n')
 
 cat('We use the `methSeg()` function to perform an unsupervised segmentation of the methylation differences calculated from `calculateDiffMeth()`. Then we classify hyper and hypo methylated segments based on the methylation difference threshold and join neighbouring segments with the same class. For details about the segmentation see [Wreczycka, et al (2017)](https://www.sciencedirect.com/science/article/pii/S0168165617315936). ')
@@ -498,7 +498,7 @@ cat('To aggregate the region level statistics we use Stouffer’s weighted Z-met
 
 ```
 
-```{r DiffMeth.find_dmr, eval=ExtractDiffMeth, echo=FALSE,warning=FALSE,message=FALSE}
+```{r DiffMeth.find_dmr, results='asis',echo=FALSE,warning=FALSE,message=FALSE}
 source(file.path(scripts_dir, "find_dmrs.R"))
 
 pdf(file.path(workdir,paste0(prefix,".find_dmr.pdf")))
@@ -512,6 +512,8 @@ if (length(unique(dmrs$seg.group)) > 1) {
     sum(dmrs$seg.group == "hypo"), " to be hypo-methylated.**"
   )
 } else {
+  # TODO: provide more detailed explanation what went wrong
+  # distinguish between "none" and other groups
   cat(
     "\n**The segments belong only to a single class,\n",
     "This could indicate the unsupervised clustering of the ",

--- a/report_templates/diffmeth.Rmd.in
+++ b/report_templates/diffmeth.Rmd.in
@@ -20,7 +20,6 @@ params:
   chrom_seqlengths:       ''
   qvalue:                 0.01
   difference:             25
-  webfetch:               ''
 
   sampleids:              ''
   treatments:             ''
@@ -99,7 +98,6 @@ nTop <- 5000
 
 cpgIsland_bedfile       <- params$cpgIsland_bedfile
 refGenes_bedfile        <- params$refGenes_bedfile
-webfetch                <- tolower(params$webfetch) %in% c("true", "yes")
 chrom_seqlengths_file   <- params$chrom_seqlengths
 
 methylDiff_file <- params$methylDiff_file
@@ -146,7 +144,7 @@ AnnotateDiffMeth  <- TRUE
 ExportDMR <- TRUE
 AnnotateDMR <- TRUE
 
-if(! (all(file.exists(cpgIsland_bedfile,refGenes_bedfile)) | webfetch )) {
+if(! (all(file.exists(cpgIsland_bedfile,refGenes_bedfile)))) {
   AnnotateDiffMeth <- FALSE
 }
 
@@ -743,26 +741,31 @@ print(p)
 ```
 
 ```{r AnnotateDiffMeth.fetch_annotations, eval=AnnotateDiffMeth}
-source(file.path(scripts_dir, "fetch_procedures.R"))
-fetched.refgenes <- lookupBedFile(type = "knownGene",
-                               filename = refGenes_bedfile,
-                               assembly = assembly,
-                               webfetch = webfetch )
-fetch_refgen_success <- !is.null(fetched.refgenes)
-fetched.cpgi <- lookupBedFile(type = "cpgIslandExt",
-                              filename =  cpgIsland_bedfile,
-                              assembly = assembly,
-                              webfetch = webfetch )
-
-fetch_cpgi_success <- !is.null(fetched.cpgi)
-
+refgenes.grl <-
+    tryCatch(
+             expr = readTranscriptFeatures(refGenes_bedfile),
+             error = function (msg) {
+                 message(paste("Error while reading transcript features:",
+                                msg))
+                 return(NULL)
+             })
+fetch_refgen_success <- !is.null(refgenes.grl)
+# read the shores and flanking regions and name the flanks as shores
+# and CpG islands as CpGi
+cpg.obj <-
+    tryCatch(
+             expr = readFeatureFlank(cpgIsland_bedfile,
+                         feature.flank.name=c("CpGi","shores")),
+             error = function (msg) {
+                 message(paste("Error while reading CpG island annotation:",
+                                msg))
+                 return(NULL)
+             })
+fetch_cpgi_success <- !is.null(cpg.obj)
 ```
 
 ```{r AnnotateDiffMeth.annotateWithGeneParts,  eval=AnnotateDiffMeth, echo=FALSE, message=FALSE, results='asis'}
 if( (fetch_refgen_success) & length(GRanges.diffmeth)!=0){
-  ## now we parse the gene features
-  refgenes.grl <- readTranscriptFeatures(fetched.refgenes)
-
   annot.gene <- annotateWithGeneParts(target = GRanges.diffmeth,
                                          feature = refgenes.grl,
                                          intersect.chr = TRUE)
@@ -921,11 +924,6 @@ fill_strip <- function(facet_ggplot, fills, plot=FALSE) {
 
 ```{r AnnotateDiffMeth.annotateWithFeatureFlank,  eval=AnnotateDiffMeth, echo=FALSE, warning=FALSE, message=FALSE ,results='asis'}
 if( (fetch_cpgi_success) & length(GRanges.diffmeth)!=0){
-
-  # read the shores and flanking regions and name the flanks as shores
-  # and CpG islands as CpGi
-    cpg.obj=readFeatureFlank(fetched.cpgi,
-                           feature.flank.name=c("CpGi","shores"))
   #
   # convert methylDiff object to GRanges and annotate
   diffCpGann=annotateWithFeatureFlank(target = GRanges.diffmeth,
@@ -1141,10 +1139,7 @@ ideoDMC_hyper_hypo(hyper = GRanges.dmr.hyper,
 
 ```{r AnnotateDMR.annotateWithGeneParts,  eval=AnnotateDMR, echo=FALSE, message=FALSE, results='asis'}
 if( (fetch_refgen_success) & length(GRanges.dmr)!=0){
-  ## now we parse the gene features
-  refgenes.grl <- readTranscriptFeatures(fetched.refgenes)
-
-  annot.dmr.gene <- annotateWithGeneParts(target = GRanges.dmr,
+  annot.dmr.gene <- genomation::annotateWithGeneParts(target = GRanges.dmr,
                                          feature = refgenes.grl,
                                          intersect.chr = TRUE)
   
@@ -1268,11 +1263,6 @@ if( (fetch_refgen_success) & length(GRanges.dmr)!=0){
 
 ```{r AnnotateDMR.annotateWithFeatureFlank,  eval=AnnotateDMR, echo=FALSE, warning=FALSE, message=FALSE ,results='asis'}
 if( (fetch_cpgi_success) & length(GRanges.dmr)!=0){
-
-  # read the shores and flanking regions and name the flanks as shores
-  # and CpG islands as CpGi
-  cpg.obj=readFeatureFlank(fetched.cpgi,
-                         feature.flank.name=c("CpGi","shores"))
 
   # convert methylDiff object to GRanges and annotate
   diffCpGann.dmr=annotateWithFeatureFlank(target = GRanges.dmr,

--- a/report_templates/diffmeth.Rmd.in
+++ b/report_templates/diffmeth.Rmd.in
@@ -301,7 +301,7 @@ The full table of methylKit calculateDiffMeth() results can be found at:
 `r methylDiff_results_file`
 
 
-```{r DiffMeth.load_methylDB, message=TRUE}
+```{r DiffMeth.map_treatment, message=TRUE}
 
 
 if (!setequal(control_group,treatment_group)) {
@@ -322,8 +322,9 @@ if (!setequal(control_group,treatment_group)) {
                 sep = ": ",collapse = "\n"))
   
 }
+```
 
-
+```{r DiffMeth.load_methylDB, results='asis'}
 methylDiffDB <- methylKit:::readMethylDiffDB(dbpath = methylDiff_file,
                                     dbtype = "tabix",
                                     sample.ids = sampleids,

--- a/report_templates/diffmeth.Rmd.in
+++ b/report_templates/diffmeth.Rmd.in
@@ -361,24 +361,7 @@ cat('- **DmC BED file**:\n',file.path(workdir,paste0(prefix,".dmc.bed")),'\n')
 
 ```
 
-```{r Diffmeth.extract_dmc, eval=ExtractDiffMeth}
-
-# Get hyper-methylated
-methylDiff.obj.hyper <- getMethylDiff(.Object = methylDiff.obj.all,
-									  difference = difference,
-									  type = "hyper",
-									  qvalue = qvalue)
-# Get hypo-methylated
-methylDiff.obj.hypo <- getMethylDiff(.Object = methylDiff.obj.all,
-									 difference = difference,
-									 type = "hypo",
-									 qvalue=qvalue)
-
-```
-
-
-```{r DiffMeth.export_dmc, eval=ExtractDiffMeth, echo=FALSE}
-
+```{r DiffMeth.export_bed, echo=FALSE}
 #-------------------------------------------------------------------
 #' Export windows to a BED file
 #'
@@ -474,7 +457,25 @@ meth2bed<-function(windows,filename,
                    trackLine=as(trackLine, "BasicTrackLine"))
     }
 }
+```
 
+```{r Diffmeth.extract_dmc, eval=ExtractDiffMeth}
+
+# Get hyper-methylated
+methylDiff.obj.hyper <- getMethylDiff(.Object = methylDiff.obj.all,
+									  difference = difference,
+									  type = "hyper",
+									  qvalue = qvalue)
+# Get hypo-methylated
+methylDiff.obj.hypo <- getMethylDiff(.Object = methylDiff.obj.all,
+									 difference = difference,
+									 type = "hypo",
+									 qvalue=qvalue)
+
+```
+
+
+```{r Diffmeth.export_dmc, eval=ExtractDiffMeth}
 # Export differentially methylated cytosines to a bed file
 bedFile <- file.path(workdir,paste0(prefix,".dmc.bed"))
 meth2bed(windows = methylDiff.obj.all,
@@ -485,8 +486,6 @@ meth2bed(windows = methylDiff.obj.all,
          scoreCol = "meth.diff",
          colramp=colorRamp(c("gray","green", "darkgreen")),
          filename = bedFile) 
-
-
 ```
 
 ```{r DiffMeth.find_dmr_text, results='asis', eval=ExtractDiffMeth}

--- a/report_templates/diffmeth.Rmd.in
+++ b/report_templates/diffmeth.Rmd.in
@@ -689,7 +689,7 @@ stats.df$variable <- factor(gsub("number.of.","",stats.df$variable),
 ```{r AnnotateDiffMeth.num_of_dmcs.plot, eval=ExtractDiffMeth,fig.width=8,fig.height=8}
 p <- ggplot(stats.df, aes(x = chr, y = perc, fill = variable)) + 
   scale_fill_manual(values = c(hypo.col,hyper.col)) +
-  geom_bar(stat = "identity",position = "stack", color = "black") +
+  ggplot2::geom_bar(stat = "identity",position = "stack", color = "black") +
   geom_text_repel(aes(label = count), position = position_stack(vjust = 0.5),
             hjust = 0.1,size = 5) +
   ggtitle(label = "Differentially methylated Cytosines per Chromosome") +
@@ -726,7 +726,7 @@ stats.DMC.df$variable <- factor(gsub("number.of.","",stats.DMC.df$variable),
 
 p <- ggplot(stats.DMC.df, aes(x = chr, y = perc, fill = variable)) + 
   scale_fill_manual(values = c(hypo.col,hyper.col)) +
-  geom_bar(stat = "identity",position = "stack", color = "black") +
+  ggplot2::geom_bar(stat = "identity",position = "stack", color = "black") +
   geom_text_repel(aes(label = count), position = position_stack(vjust = 0.5),
             hjust = 0.1,size = 5) +
   ggtitle(label = "Differentially methylated Cytosines per Chromosome") +
@@ -812,7 +812,7 @@ if( (fetch_refgen_success) & length(GRanges.diffmeth)!=0){
   
   p <- ggplot(df, aes(x = variable, y = value, fill = variable)) + 
     scale_fill_manual(values = rev(cols)) +
-    geom_bar(stat = "identity" ,color = "black", position = position_dodge()) +
+    ggplot2::geom_bar(stat = "identity" ,color = "black", position = position_dodge()) +
     geom_text(aes(y = -10, label = count), hjust = 0,size = 5) +
     ggtitle(label = "Differentially methylated Cytosines per Genomic Feature") +
     labs(y = "Percentage", x = "Feature") + 
@@ -882,7 +882,7 @@ fill_strip <- function(facet_ggplot, fills, plot=FALSE) {
     
     p <- ggplot(df, aes(x = variable, y = value, fill = variable)) + 
       scale_fill_manual(values = rev(cols)) +
-      geom_bar(mapping = aes(group = type), stat = "identity" ,color = "black",  position = position_dodge()) +
+      ggplot2::geom_bar(mapping = aes(group = type), stat = "identity" ,color = "black",  position = position_dodge()) +
       geom_text(mapping = aes(group = type, color = type , y = -10, label = count), size = 5, 
                   position = position_dodge(width= 1)) +
       scale_color_manual(values = c(hypo.col,hyper.col)) + 
@@ -979,7 +979,7 @@ if( (fetch_cpgi_success) & length(GRanges.diffmeth)!=0){
   
   p <- ggplot(df, aes(x = variable, y = value, fill = variable)) + 
   scale_fill_manual(values = c("white","gray","green")) +
-  geom_bar(stat = "identity" ,color = "black", position = position_dodge()) +
+  ggplot2::geom_bar(stat = "identity" ,color = "black", position = position_dodge()) +
     geom_text(aes(y = -10, label = count), hjust = 0,size = 5) +
   coord_flip() +
   labs(y = "Percentage", x = "Feature") + 
@@ -1018,7 +1018,7 @@ if( length(GRanges.diffmeth.hypo)!=0 & length(GRanges.diffmeth.hyper)!=0){
   
   p <- ggplot(df, aes(x = variable, y = value, fill = variable)) + 
   scale_fill_manual(values = c("white","gray","green")) +
-  geom_bar(mapping = aes(group = type), stat = "identity" ,color = "black",  position = position_dodge()) +
+  ggplot2::geom_bar(mapping = aes(group = type), stat = "identity" ,color = "black",  position = position_dodge()) +
   geom_text(mapping = aes(group = type, color = type , y = -10, label = count), size = 5, 
             position = position_dodge(width= 1)) +
   scale_color_manual(values = c(hypo.col,hyper.col)) +
@@ -1193,7 +1193,7 @@ if( (fetch_refgen_success) & length(GRanges.dmr)!=0){
   
   p <- ggplot(df, aes(x = variable, y = value, fill = variable)) + 
     scale_fill_manual(values = rev(cols)) +
-    geom_bar(stat = "identity" ,color = "black", position = position_dodge()) +
+    ggplot2::geom_bar(stat = "identity" ,color = "black", position = position_dodge()) +
     geom_text(aes(y = -10, label = count), hjust = 0,size = 5) +
     ggtitle(label = "Differentially methylated Regions per Genomic Feature") +
     labs(y = "Percentage", x = "Feature") + 
@@ -1229,7 +1229,7 @@ if( (fetch_refgen_success) & length(GRanges.dmr)!=0){
     
     p <- ggplot(df, aes(x = variable, y = value, fill = variable)) + 
       scale_fill_manual(values = rev(cols)) +
-      geom_bar(mapping = aes(group = type), stat = "identity" ,color = "black",  position = position_dodge()) +
+      ggplot2::geom_bar(mapping = aes(group = type), stat = "identity" ,color = "black",  position = position_dodge()) +
       geom_text(mapping = aes(group = type, color = type , y = -10, label = count), size = 5, 
                   position = position_dodge(width= 1)) +
       scale_color_manual(values = c(hypo.col,hyper.col)) + 
@@ -1326,7 +1326,7 @@ if( (fetch_cpgi_success) & length(GRanges.dmr)!=0){
   
   p <- ggplot(df, aes(x = variable, y = value, fill = variable)) + 
   scale_fill_manual(values = c("white","gray","green")) +
-  geom_bar(stat = "identity" ,color = "black", position = position_dodge()) +
+  ggplot2::geom_bar(stat = "identity" ,color = "black", position = position_dodge()) +
     geom_text(aes(y = -10, label = count), hjust = 0,size = 5) +
   coord_flip() +
   labs(y = "Percentage", x = "Feature") + 
@@ -1365,7 +1365,7 @@ if( length(GRanges.dmr.hypo)!=0 & length(GRanges.dmr.hyper)!=0){
   
   p <- ggplot(df, aes(x = variable, y = value, fill = variable)) + 
   scale_fill_manual(values = c("white","gray","green")) +
-  geom_bar(mapping = aes(group = type), stat = "identity" ,color = "black",  position = position_dodge()) +
+  ggplot2::geom_bar(mapping = aes(group = type), stat = "identity" ,color = "black",  position = position_dodge()) +
   geom_text(mapping = aes(group = type, color = type , y = -10, label = count), size = 5, 
             position = position_dodge(width= 1)) +
   scale_color_manual(values = c(hypo.col,hyper.col)) +

--- a/report_templates/diffmeth.Rmd.in
+++ b/report_templates/diffmeth.Rmd.in
@@ -341,13 +341,13 @@ methylDiff.obj.all <- getMethylDiff(.Object = methylDiffDB,
 									save.db = FALSE)
 
 # Check if there are some differentially methylated cytosines
-if (! nrow(methylDiff.obj.all)>1 ) {
-	cat("\n**There are no differentially methylated cytosines.**")
-	ExtractDiffMeth <- FALSE
-	AnnotateDiffMeth <- FALSE
+if (nrow(methylDiff.obj.all) > 1) {
+  cat("\n**We found ", nrow(methylDiff.obj.all), " cytosines to be differentially methylated .**")
 } else {
-    cat("\n**We found ",nrow(methylDiff.obj.all)," cytosines to be differentially methylated .**")
-  }
+  cat("\n**There are no differentially methylated cytosines.**")
+  ExtractDiffMeth <- FALSE
+  AnnotateDiffMeth <- FALSE
+}
 
 ```
 
@@ -505,20 +505,22 @@ pdf(file.path(workdir,paste0(prefix,".find_dmr.pdf")))
 dmrs <- find_DMR(methylDiffDB,cores = cores)
 invisible(dev.off())
 
-if(! length(unique(dmrs$seg.group)) > 1 ) {
+if (length(unique(dmrs$seg.group)) > 1) {
+  cat(
+    "\n**The segmentation was successful, out of ", length(dmrs), " regions ",
+    "we found ", sum(dmrs$seg.group == "hyper"), "to be hyper-methylated and ",
+    sum(dmrs$seg.group == "hypo"), " to be hypo-methylated.**"
+  )
+} else {
   cat(
     "\n**The segments belong only to a single class,\n",
     "This could indicate the unsupervised clustering of the ",
     "segments was not successful or the difference in methylation ",
     "is not high enough.**"
   )
-	ExportDMR <- FALSE
-	AnnotateDMR <- FALSE
-} else {
-    cat("\n**The segmentation was successful, out of ",length(dmrs)," regions ",
-    "we found ",sum(dmrs$seg.group == "hyper") ,"to be hyper-methylated and ",
-    sum(dmrs$seg.group == "hypo"), " to be hypo-methylated.**")
-  }
+  ExportDMR <- FALSE
+  AnnotateDMR <- FALSE
+}
 ```
 
 ```{r DiffMeth.export_dmr_text, results='asis', eval=ExportDMR}

--- a/report_templates/index.Rmd.in
+++ b/report_templates/index.Rmd.in
@@ -67,6 +67,13 @@ knitr::opts_chunk$set(echo = FALSE, warning = FALSE, message = FALSE, fig.height
 knitr::opts_knit$set(progress = FALSE)
 ```
 
+```{r load_libraries, results='hide', include=FALSE}
+  library("genomation")
+  library("methylKit")
+  library("GenomicRanges")
+  library("DT")
+```
+
 ```{r chunk_eval_options}
 MethCall          <- TRUE
 Segmentation      <- TRUE
@@ -132,11 +139,6 @@ knitr::kable(basic_inputParams)
 ```{r MethCallHeader, results='asis', eval=MethCall} 
 cat('## Methylation Calling\n')
 cat('The following table(s) lists some of the basic parameters under which the pipeline calculations were performed as well as output files that may be of interest to the user for further analysis.')
-```
-
-```{r MethCall.load_libraries, results='hide', include=FALSE, eval=MethCall}
-  library("genomation")
-  library("methylKit")
 ```
 
 ```{r MethCall.eval_params, eval=MethCall}
@@ -240,12 +242,7 @@ if( methsegempty )
    }
 ```
 
-```{r Segmentation.load_libraries, results='hide', include=FALSE, eval= Segmentation }
 
-  ## load methylKit
-  library("methylKit")
-  library("DT")
-```
 
 ```{r SegmentationDescription, results='asis', eval= Segmentation } 
 cat('### Segmentation of Methylation Profile\n')
@@ -285,13 +282,6 @@ cat('The annotation of the identified regions with genomic features allows for a
 
 cat('Pigx first searches for a reference gene set for the given genome assembly in the path specified in the settings file. Upon failure to find such a file in this location, Pigx allows the user to query the UCSC table browser directly to fetch the reference gene set using the [rtracklayer](http://bioconductor.org/packages/release/bioc/html/rtracklayer.html) Package [@rtracklayer2009], when the option `webfetch` (in the settings file) is set to `True` -or, equivalently, `yes`. When this option is set to `False` --or `no`--, and the reference gene files are not found, the corresponding sections are simply omitted from this report. 
 Upon acquiring the reference genes, we can determine different features (e.g. promoter, exon, intron)  intrinsic to each gene,  using the `readTranscriptFeatures()` function from [genomation](http://bioinformatics.mdc-berlin.de/genomation/) [@genomation2014] --likewise, for CpG islands and shores.\n')
-```
-
-```{r AnnotateSegments.load_libraries, results='hide', include=FALSE, eval= AnnotateSegments }
-
-    library("genomation")
-    library("GenomicRanges")
-
 ```
 
 

--- a/report_templates/index.Rmd.in
+++ b/report_templates/index.Rmd.in
@@ -76,7 +76,7 @@ knitr::opts_knit$set(progress = FALSE)
 ```{r chunk_eval_options}
 MethCall          <- TRUE
 Segmentation      <- TRUE
-AnnotateSegments  <- TRUE
+Annotation          <- TRUE
 
 inBam <- params$inBam
 bigwigFile <- params$bigwigFile
@@ -87,16 +87,19 @@ scripts_dir  <- params$scripts_dir
 
 if(!MethCall) {
   Segmentation <- 
-  AnnotateSegments <- 
+  Annotation <-
     FALSE
 }
 
-if(!Segmentation) AnnotateSegments <- FALSE
+if(!Segmentation) Annotation <- FALSE
+
+if(!file.exists(refGenes_bedfile)) {
+       Annotation <- FALSE
+}
 
 ```
 
-# Final Report {-}
-
+# Description
 
 PiGx BSseq is a data-processing pipeline for bisulfite experiments; it automates the analysis of raw single-end or paired-end fastq reads, including quality control, trimming and alignment. The software also provides post-mapping analysis, such as differential-methylation detection, methylation segmentation, and annotation of such detected regions. 
 It was first developed by the Akalin group at MDC in Berlin in 2017.
@@ -132,7 +135,7 @@ knitr::kable(basic_inputParams)
 ```
 
 ```{r MethCallHeader, results='asis', eval=MethCall} 
-cat('## Methylation Calling\n')
+cat('# Methylation Calling\n')
 cat('The following table(s) lists some of the basic parameters under which the pipeline calculations were performed as well as output files that may be of interest to the user for further analysis.')
 ```
 
@@ -179,7 +182,7 @@ knitr::kable(inputParams)
 ```
 
 ```{r MethCallDescription, results='asis', eval=MethCall} 
-cat('### Extract Methylation Calls \n')
+cat('## Extract Methylation Calls \n')
 
 cat('We first extract the methylation calls from the sequence alignment produced by the bisulfite mapper [Bismark](https://www.bioinformatics.babraham.ac.uk/projects/bismark/) [@krueger_bismark:_2011] using the `processBismarkAln()` function of [methylKit](https://bioconductor.org/packages/release/bioc/html/methylKit.html) [@methylKit2012] --a package for the  analysis of DNA methylation profiles. 
 We apply filters based on a minimum coverage of ',mincov,' and a mapping quality of at least ',minqual,', as indicated in the parameters table.\n')
@@ -207,7 +210,7 @@ cat('Here we show some simple statistics related to the distribution of methylat
 
 
 ```{r Segmentation, results='asis', eval=Segmentation} 
-cat('## Segmentation \n')
+cat('# Segmentation \n')
 ```
 
 ```{r Segmentation.eval_params, eval=Segmentation}
@@ -232,15 +235,14 @@ cat('For the present data set, however, there exist chromosomes that could not b
 if( methsegempty )
    {
    Segmentation         <- FALSE;
-   AnnotateSegments     <- FALSE;
-   fetch_refgen_success <- FALSE;
+   Annotation     <- FALSE;
    }
 ```
 
 
 
 ```{r SegmentationDescription, results='asis', eval= Segmentation } 
-cat('### Segmentation of Methylation Profile\n')
+cat('## Segmentation of Methylation Profile\n')
 
 cat('Segmentation of the methylation profile is done using the methSeg() function, where change-points in the genome-wide  signal are recorded and the genome is partitioned into regions between consecutive change-points. This approach is typically used in the detection of copy-number variation [@klambauer2012] but can be applied to methylome segmentation as well [@Wreczycka2017]. Here, the identified segments are further clustered based on their average methylation signal, using a mixture-modeling approach, which permits the detection of distinct regions inside the genome  [@Wreczycka2017].\n')
 ```
@@ -258,7 +260,7 @@ cat('For the given sample, there were insufficient segments detected to perform 
 ```
 
 ```{r SegmentationExport, results='asis', eval= Segmentation }
-cat('### Export to BED\n')
+cat('## Export to BED\n')
 
 cat('We export the above regions to a *BED* file, which can be loaded into any genome browser (such as [IGV](http://software.broadinstitute.org/software/igv/) or [UCSC](https://genome.ucsc.edu/) ) to allow for further analysis, annotation and visualisation.\n')
 
@@ -267,8 +269,6 @@ cat('- **Methylation Segments BED file**:\n',methSegBed ,'\n')
 ```
 
 ```{r Annotation.readRefGene,  results='asis', eval= Annotation }
-
-require(genomation,quietly = TRUE)
 ## now we parse the gene features
 refgenes.grl <- tryCatch(
                          expr = readTranscriptFeatures(refGenes_bedfile),
@@ -291,33 +291,7 @@ cat('The annotation of the identified regions with genomic features allows for a
 
 
 
-```{r AnnotateSegments.fetchRefgene, eval= AnnotateSegments }
-originally_present_refgen = file.exists(refGenes_bedfile)
-source(paste0(scripts_dir, "fetch_procedures.R"))
-fetched.refgenes <- lookupBedFile(type      = "refGene",
-                                  filename  = refGenes_bedfile,
-                                  assembly  = assembly,
-                                  webfetch  = webfetch )
-fetch_refgen_success <- ( fetched.refgenes != '')
-```
-
-```{r AnnotateSegments.readRefGene,  results='asis', eval= AnnotateSegments }
-
-## now we parse the gene features
-if( fetch_refgen_success ) {
-  cat( paste( "In this particular execution of the pipeline, the reference gene set was obtained, while the option webfetch was set to =", webfetch) )
-  if( !webfetch )
-    {cat('; this implies that the .bed file was found locally on the machine.') }
-  if( webfetch && !originally_present_refgen)
-    { cat('\n since the reference gene file was not originally present, this implies that it was downloaded remotely from the UCSC server.') }
-  refgenes.grl <- readTranscriptFeatures(fetched.refgenes)
-  } else { 
-  cat( paste(" In this particular execution of the pipeline, PiGx failed to find the reference gene file ", refGenes_bedfile, ", while the option webfetch was set to =", webfetch, ". Thus, the corresponding section was omitted.") )
-  }
-```
-
-```{r AnnotateSegments.loadSegments, eval= AnnotateSegments }
-
+```{r Annotation.loadSegments, eval= Annotation }
 # now load segments 
 segments.gr <- readBed(file = methSegBed,
                       track.line = "auto")
@@ -338,11 +312,11 @@ annot.gene.list <- annotateWithGeneParts(target = segments.grl,
                                         intersect.chr = TRUE)
 ```
 
-```{r AnnotateSegments.text2, results='asis', eval= AnnotateSegments }
+```{r Annotation.text2, results='asis', eval= Annotation }
 cat('Here, we plot the average methylation per segment group and the overlap with gene features for the input reference gene set.\n')
 ```
 
-```{r AnnotateSegments.plot,  eval= AnnotateSegments }
+```{r Annotation.plot,  eval= Annotation }
 ## percentage of target features overlapping with annotation:
 ## (with promoter > exon > intron precedence)
 annot.gene.mat <- as.matrix(sapply(annot.gene.list, function(x) x@precedence))
@@ -361,7 +335,7 @@ legend("bottomright",legend = rownames(annot.gene.mat),fill = grey(seq.int(0,1,l
 ```
 
 
-```{r plot_methylation_near_TSSs, results='asis', eval = fetch_refgen_success }
+```{r plot_methylation_near_TSSs, results='asis', eval = Annotation }
 
 TSS_plotlength  <- as.integer(params$TSS_plotlength)
 ymin = 0
@@ -370,11 +344,6 @@ ymax = 100
 gene_features   <- refgenes.grl
 TSS_exact       <- gene_features$TSSes
 TSS_proximal    <- resize(TSS_exact, width=TSS_plotlength, fix='center')
-
-# following lines commented out for efficiency
-# sample_methylome_gr          <-  as(methRaw, "GRanges")
-# sample_methylome_gr$methfrac <-  sample_methylome_gr$numCs/sample_methylome_gr$coverage
-# TSSprox_scoremat_noweight = genomation::ScoreMatrix( sample_methylome_gr,
 
 TSSprox_scoremat_noweight <- tryCatch(
 									  expr = {

--- a/report_templates/index.Rmd.in
+++ b/report_templates/index.Rmd.in
@@ -29,7 +29,6 @@ params:
   methSegPng: ''
   scripts_dir: ''
   refGenes_bedfile:   ''
-  webfetch:     ''
   
   prefix:                 ''
   workdir:                ''
@@ -82,11 +81,7 @@ AnnotateSegments  <- TRUE
 inBam <- params$inBam
 bigwigFile <- params$bigwigFile
 
-
 refGenes_bedfile        <- params$refGenes_bedfile
-webfetch                <- tolower(params$webfetch) %in% c("true", "yes")
-
-
 
 scripts_dir  <- params$scripts_dir
 
@@ -271,18 +266,29 @@ cat('- **Methylation Segments BED file**:\n',methSegBed ,'\n')
 
 ```
 
-```{r AnnotateSegmentsHeader, results='asis', eval= AnnotateSegments }
+```{r Annotation.readRefGene,  results='asis', eval= Annotation }
+
+require(genomation,quietly = TRUE)
+## now we parse the gene features
+refgenes.grl <- tryCatch(
+                         expr = readTranscriptFeatures(refGenes_bedfile),
+                         error = function (msg) {
+                             message(paste0("Error while reading transcript features: ", msg))
+                             return(NULL)
+                         })
+
+if( is.null(refgenes.grl) ) {
+    Annotation <- FALSE
+  cat( paste(" In this particular execution of the pipeline, PiGx failed to find the load the gene annotation file ", refGenes_bedfile, ". Thus, the corresponding section was omitted.") )
+  }
+```
+
+```{r AnnotationHeader, results='asis', eval= Annotation }
 cat('## Annotation of Segments\n')
 
 cat('The annotation of the identified regions with genomic features allows for a better understanding and characterization of detected regions.\n')
 ```
 
-
-```{r AnnotateSegmentsDescription, results='asis',eval= AnnotateSegments }
-
-cat('Pigx first searches for a reference gene set for the given genome assembly in the path specified in the settings file. Upon failure to find such a file in this location, Pigx allows the user to query the UCSC table browser directly to fetch the reference gene set using the [rtracklayer](http://bioconductor.org/packages/release/bioc/html/rtracklayer.html) Package [@rtracklayer2009], when the option `webfetch` (in the settings file) is set to `True` -or, equivalently, `yes`. When this option is set to `False` --or `no`--, and the reference gene files are not found, the corresponding sections are simply omitted from this report. 
-Upon acquiring the reference genes, we can determine different features (e.g. promoter, exon, intron)  intrinsic to each gene,  using the `readTranscriptFeatures()` function from [genomation](http://bioinformatics.mdc-berlin.de/genomation/) [@genomation2014] --likewise, for CpG islands and shores.\n')
-```
 
 
 ```{r AnnotateSegments.fetchRefgene, eval= AnnotateSegments }
@@ -327,12 +333,9 @@ segments.grl <- GenomicRanges::split(
   f = overlapping_segments.gr$name
 )
 
-if( fetch_refgen_success )
-  { 
-  annot.gene.list <- annotateWithGeneParts(target = segments.grl,
-                                           feature = refgenes.grl,
-                                           intersect.chr = TRUE)
-  }
+annot.gene.list <- annotateWithGeneParts(target = segments.grl,
+                                        feature = refgenes.grl,
+                                        intersect.chr = TRUE)
 ```
 
 ```{r AnnotateSegments.text2, results='asis', eval= AnnotateSegments }
@@ -342,26 +345,19 @@ cat('Here, we plot the average methylation per segment group and the overlap wit
 ```{r AnnotateSegments.plot,  eval= AnnotateSegments }
 ## percentage of target features overlapping with annotation:
 ## (with promoter > exon > intron precedence)
-if( fetch_refgen_success )
-  { 
-  annot.gene.mat <- as.matrix(sapply(annot.gene.list, function(x) x@precedence))
-  }
+annot.gene.mat <- as.matrix(sapply(annot.gene.list, function(x) x@precedence))
 
-  par(mfrow=c(1,2))
+par(mfrow=c(1,2))
 boxplot(sapply(split(x = overlapping_segments.gr,f = overlapping_segments.gr$name),FUN = function(x) x$score),
         ylab = "Methylation (%)", 
         xlab = "Segment")
 
-if( fetch_refgen_success )
-  { 
-  # plot the target overlap for each segemnt type
-  # barplot(annot.gene.mat,legend.text = TRUE)
-  barplot(annot.gene.mat,
-          ylab = "Overlap (%)",
-          xlab = "Segment")
-  legend("bottomright",legend = rownames(annot.gene.mat),fill = grey(seq.int(0,1,length.out = ncol(annot.gene.mat))))
-  }
-
+# plot the target overlap for each segemnt type
+# barplot(annot.gene.mat,legend.text = TRUE)
+barplot(annot.gene.mat,
+        ylab = "Overlap (%)",
+        xlab = "Segment")
+legend("bottomright",legend = rownames(annot.gene.mat),fill = grey(seq.int(0,1,length.out = ncol(annot.gene.mat))))
 ```
 
 

--- a/report_templates/index.Rmd.in
+++ b/report_templates/index.Rmd.in
@@ -34,12 +34,6 @@ params:
   prefix:                 ''
   workdir:                ''
   logo:                   ''
-  
-  MethCall: TRUE
-  AnnotateDiffMeth: TRUE
-  AnnotateSegments: TRUE
-  DiffMeth: TRUE
-  Segmentation: TRUE
 ---
 
 <style>
@@ -74,9 +68,9 @@ knitr::opts_knit$set(progress = FALSE)
 ```
 
 ```{r chunk_eval_options}
-MethCall          <- params$MethCall
-Segmentation      <- params$Segmentation
-AnnotateSegments  <- params$AnnotateSegments
+MethCall          <- TRUE
+Segmentation      <- TRUE
+AnnotateSegments  <- TRUE
 
 inBam <- params$inBam
 bigwigFile <- params$bigwigFile

--- a/report_templates/index.Rmd.in
+++ b/report_templates/index.Rmd.in
@@ -316,10 +316,16 @@ if( fetch_refgen_success ) {
 segments.gr <- readBed(file = methSegBed,
                       track.line = "auto")
 
-# split according
-segments.grl <- GenomicRanges::split(x = segments.gr,f = segments.gr$name)
+# intersect by overlaping chroms
+shared_chroms <- intersect(seqlevels(segments.gr), seqlevels(refgenes.grl))
+dropped_chroms <- setdiff(seqlevels(segments.gr), shared_chroms)
+overlapping_segments.gr <- segments.gr[seqnames(segments.gr) %in% shared_chroms]
 
-# and detect overlaps 
+# split by segment groups
+segments.grl <- GenomicRanges::split(
+  x = overlapping_segments.gr,
+  f = overlapping_segments.gr$name
+)
 
 if( fetch_refgen_success )
   { 
@@ -342,8 +348,8 @@ if( fetch_refgen_success )
   }
 
   par(mfrow=c(1,2))
-boxplot(sapply(split(x = segments.gr,f = segments.gr$name),FUN = function(x) x$score),
-        ylab = "Methylation (%)",
+boxplot(sapply(split(x = overlapping_segments.gr,f = overlapping_segments.gr$name),FUN = function(x) x$score),
+        ylab = "Methylation (%)", 
         xlab = "Segment")
 
 if( fetch_refgen_success )

--- a/rules/perform_diffmeth.py
+++ b/rules/perform_diffmeth.py
@@ -155,7 +155,6 @@ rule diffmeth_report:
         chrom_seqlengths       = os.path.join(DIR_mapped,ASSEMBLY+"_chromlengths.csv"),
         qvalue                 = float(config['general']['differential-methylation']['qvalue']),
         difference             = float(config['general']['differential-methylation']['difference']),
-        webfetch               = WEBFETCH,
         # required for any report
         bibTexFile             = BIBTEXPATH,
         prefix                 = "{analysis}_{context}_{tool}",
@@ -194,8 +193,7 @@ rule diffmeth_report:
                                '"refGenes_bedfile":"{params.refGenes_bedfile}"',
                                '"chrom_seqlengths":"{params.chrom_seqlengths}"',
                                '"qvalue":"{params.qvalue}"',
-                               '"difference":"{params.difference}"',
-                               '"webfetch":"{params.webfetch}"'
+                               '"difference":"{params.difference}"'
                            ])+"}}'",
                            "--logFile={log}"], "{log}", 
                            "echo '' ")

--- a/scripts/fetch_procedures.R
+++ b/scripts/fetch_procedures.R
@@ -114,8 +114,9 @@ lookupBedFile <- function(type, filename, assembly, webfetch) {
     return(filename)
   }
   
-  if(!(type %in% c("cpgIslandExt", "knownGene"))) {
-    stop('ERROR: type can be either "cpgIslandExt" or "knownGene".')
+  accepted_types <- c("cpgIslandExt", "knownGene", "refGene")
+  if(!(type %in% accepted_types)) {
+    stop(paste0("Type <'",type,"'> not supported. Please use one of the following: ",paste(accepted_types,collapse=", ")))
   }
 
   message("Trying to fetch from AnnotationHub.\n")

--- a/scripts/generate_report.R
+++ b/scripts/generate_report.R
@@ -31,17 +31,17 @@
 #' @param workdir working directory
 #' @param report.params
 #' @param logo Location of PiGx logo
-#' @param quiet boolean value (default: FALSE). If set to TRUE, progress bars 
+#' @param quiet boolean value (default: FALSE). If set to TRUE, progress bars
 #'   and chunk labels will be suppressed while knitting the Rmd file.
 #' @param selfContained boolean value (default: TRUE). By default, the generated
-#'   html file will be self-contained, which means that all figures and tables 
-#'   will be embedded in a single html file with no external dependencies (See 
+#'   html file will be self-contained, which means that all figures and tables
+#'   will be embedded in a single html file with no external dependencies (See
 #'   rmarkdown::html_document)
 #' @param bibTexFile path to bibTex biblographie file
 #' @param prefix prefix for report
-#'   
-#' @return An html generated using rmarkdown/knitr/pandoc that contains 
-#'   interactive figures, tables, and text that provide an overview of the 
+#'
+#' @return An html generated using rmarkdown/knitr/pandoc that contains
+#'   interactive figures, tables, and text that provide an overview of the
 #'   experiment
 #' @export
 #'
@@ -53,13 +53,10 @@ render2HTML <- function(reportFile,
                         logo,
                         bibTexFile,
                         prefix,
-                        selfContained=TRUE,
-                        quiet = FALSE
-                        )
-{
-
+                        selfContained = TRUE,
+                        quiet = FALSE) {
   if (is.null(report.params)) report.params <- list()
-  
+
   ## render single report
   message("rendering report from template: ", reportFile)
 
@@ -76,22 +73,23 @@ render2HTML <- function(reportFile,
       toc = TRUE,
       depth = 2,
       toc_float = TRUE,
-      theme = 'lumen',
+      theme = "lumen",
       number_sections = TRUE,
       code_folding = "hide",
       bibliography = bibTexFile
     ),
     output_options = list(self_contained = selfContained),
     params = c(report.params,
-               logo = logo,
-               prefix = prefix,
-               workdir = workdir),
-    quiet  = quiet,
-    clean  = TRUE
+      logo = logo,
+      prefix = prefix,
+      workdir = workdir
+    ),
+    quiet = quiet,
+    clean = TRUE
   )
-	if(dir.exists(file.path(workdir, prefix))) {
-			unlink(file.path(workdir, prefix), recursive = TRUE)
-	  }
+  if (dir.exists(file.path(workdir, prefix))) {
+    unlink(file.path(workdir, prefix), recursive = TRUE)
+  }
 }
 
 
@@ -101,12 +99,12 @@ render2HTML <- function(reportFile,
 args <- commandArgs(TRUE)
 
 ## Default setting when no arguments passed
-if(length(args) < 1) {
+if (length(args) < 1) {
   args <- c("--help")
 }
 
 ## Help section
-if("--help" %in% args) {
+if ("--help" %in% args) {
   cat("
       Render to report
 
@@ -125,7 +123,7 @@ if("--help" %in% args) {
       Example:
       ./test.R --arg1=1 --arg2='output.txt' --arg3=TRUE \n\n")
 
-  q(save="no")
+  q(save = "no")
 }
 
 ## Parse arguments (we expect the form --arg=value)
@@ -136,16 +134,16 @@ argsL <- as.list(as.character(argsDF$V2))
 names(argsL) <- argsDF$V1
 
 ## catch output and messages into log file
-if(!is.null(argsL$logFile)) {
+if (!is.null(argsL$logFile)) {
   out <- file(argsL$logFile, open = "at")
-  sink(out,type = "output")
+  sink(out, type = "output")
   sink(out, type = "message")
 } else {
   sink()
 }
 
 ## get deeper list elements of report params
-if(!is.null(argsL$report.params)) {
+if (!is.null(argsL$report.params)) {
   argsL$report.params <- jsonlite::fromJSON(argsL$report.params)
 }
 
@@ -160,12 +158,13 @@ jsonlite::write_json(
 message("========= Given Parameters ==========")
 print(argsL)
 
-## check wether all required report params are given 
+## check wether all required report params are given
 paramsList <- knitr::knit_params(readLines(argsL$reportFile),
-                                 evaluate = TRUE)
+  evaluate = TRUE
+)
 
 ## exclude standard report params
-paramsList <- paramsList[!names(paramsList) %in% c("logo","prefix","workdir")]
+paramsList <- paramsList[!names(paramsList) %in% c("logo", "prefix", "workdir")]
 
 givenParams <- names(paramsList) %in% names(argsL$report.params)
 if (!all(givenParams)) {
@@ -178,22 +177,24 @@ message("====================================")
 
 
 cat(paste(
-    format(as.POSIXct(if ("" != Sys.getenv("SOURCE_DATE_EPOCH")) {
-                          as.numeric(Sys.getenv("SOURCE_DATE_EPOCH"))
-                      } else {
-                          Sys.time()
-                      }, origin="1970-01-01"), "%Y-%m-%d %H:%M:%S"),
-    "\n\n",
+  format(as.POSIXct(if ("" != Sys.getenv("SOURCE_DATE_EPOCH")) {
+    as.numeric(Sys.getenv("SOURCE_DATE_EPOCH"))
+  } else {
+    Sys.time()
+  }, origin = "1970-01-01"), "%Y-%m-%d %H:%M:%S"),
+  "\n\n",
   "Rendering report:", basename(argsL$outFile), "\n",
   "into directory:", argsL$workdir, "\n\n"
 ))
 
 
-render2HTML(reportFile = normalizePath(argsL$reportFile),
-      outFile = basename(argsL$outFile),
-      workdir = argsL$workdir,
-      report.params = argsL$report.params,
-      logo = argsL$logo,
-      bibTexFile = argsL$bibTexFile,
-      prefix = argsL$prefix,
-      selfContained = TRUE)
+render2HTML(
+  reportFile = normalizePath(argsL$reportFile),
+  outFile = basename(argsL$outFile),
+  workdir = argsL$workdir,
+  report.params = argsL$report.params,
+  logo = argsL$logo,
+  bibTexFile = argsL$bibTexFile,
+  prefix = argsL$prefix,
+  selfContained = TRUE
+)

--- a/scripts/generate_report.R
+++ b/scripts/generate_report.R
@@ -144,17 +144,21 @@ if(!is.null(argsL$logFile)) {
   sink()
 }
 
-# export a copy of the argument list for this rendering attempt
-saveRDS( argsL, file=paste0(argsL$outFile,".RenderArgs.rds") )
-message("========= Given Parameters ==========")
-print(argsL)
-message("====================================")
-
 ## get deeper list elements of report params
 if(!is.null(argsL$report.params)) {
   argsL$report.params <- jsonlite::fromJSON(argsL$report.params)
 }
 
+# export a copy of the argument list for this rendering attempt
+message("Exporting a copy of the argument list for this rendering attempt.\n", "For debugging, please load arguments via:")
+cat("\n", paste0('params = jsonlite::read_json("', gsub("html", "RenderArgs.json", argsL$outFile), '", simplifyVector=TRUE)'), "\n\n")
+jsonlite::write_json(
+  with(argsL, c(report.params, logo = logo, prefix = prefix, workdir = workdir)),
+  path = gsub("html", "RenderArgs.json", argsL$outFile),  pretty = TRUE
+)
+
+message("========= Given Parameters ==========")
+print(argsL)
 
 ## check wether all required report params are given 
 paramsList <- knitr::knit_params(readLines(argsL$reportFile),
@@ -164,10 +168,13 @@ paramsList <- knitr::knit_params(readLines(argsL$reportFile),
 paramsList <- paramsList[!names(paramsList) %in% c("logo","prefix","workdir")]
 
 givenParams <- names(paramsList) %in% names(argsL$report.params)
-if( !all(givenParams ))  {
-  warning("Missing values for parameters: ",
-          paste(names(paramsList)[!givenParams],collapse = ", "))
+if (!all(givenParams)) {
+  warning(
+    "--------- Missing values for parameters: ----------", "\n",
+    paste(names(paramsList)[!givenParams], collapse = ", ")
+  )
 }
+message("====================================")
 
 
 cat(paste(

--- a/scripts/generate_report.R
+++ b/scripts/generate_report.R
@@ -177,9 +177,8 @@ cat(paste(
                           Sys.time()
                       }, origin="1970-01-01"), "%Y-%m-%d %H:%M:%S"),
     "\n\n",
-    "Rendering report:",basename(argsL$reportFile),"\n",
-    "from template:",basename(argsL$outFile),"\n",
-    "into directory:",argsL$workdir ,"\n\n"
+  "Rendering report:", basename(argsL$outFile), "\n",
+  "into directory:", argsL$workdir, "\n\n"
 ))
 
 

--- a/scripts/ideoDMC.R
+++ b/scripts/ideoDMC.R
@@ -46,7 +46,8 @@ ideoDMC <- function(methylDiff.obj, chrom.length, difference = 25,
   require(methylKit)
   require(GenomicRanges)
   require(ggbio)
-  
+  # TODO: rewrite the require statement as library::function calls to not pollute the reports environment
+
   # chrom.length
   myIdeo <- GRanges(seqnames = names(chrom.length), ranges = IRanges(start = 1, 
                                                                      width = chrom.length))

--- a/scripts/validate_config.py
+++ b/scripts/validate_config.py
@@ -110,13 +110,20 @@ def parse_samples(lines):
 # check for common input/configuration errors:
 def validate_config(config):
     # Check that all locations exist
-    for loc in config['locations']:
+    required_locations = ['input-dir', 'output-dir', 'genome-fasta']
+    for loc in required_locations:
         if ( (not loc == 'output-dir') and (not (os.path.isdir(config['locations'][loc]) or os.path.isfile(config['locations'][loc])))):
             bail("ERROR: The following necessary directory/file does not exist: {} ({})".format(
                 config['locations'][loc], loc))
+    optional_locations = ['cpgIsland-bedfile', 'refGenes-bedfile']
+    for loc in optional_locations:
+        if ( config['locations'][loc] and ( not os.path.isfile(config['locations'][loc]))):
+            bail("ERROR: The following optional file does not exist: {} ({})".format(
+                config['locations'][loc], loc))
+    
 
 
-        # Load parameters specific to samples
+    # Load parameters specific to samples
     with open(config['locations']['sample-sheet'], 'r') as f:
             lines = f.read().splitlines()
     sample_params = parse_samples(lines)
@@ -141,6 +148,14 @@ def validate_config(config):
     if 'treatment-groups' in config['general']['differential-methylation']:
         bail("ERROR: The specification of treatment groups and differential analysis has changed.\n"+
         "Please retrieve the new default settings layout with 'pigx-bsseq --init settings'.\n")
+
+
+    # check for new annotation layout
+    if 'annotation' in config['general']['differential-methylation']:
+        bail("ERROR: The specification of annotation files has changed.\n"+
+        "Please retrieve the new default settings layout with 'pigx-bsseq --init settings'.\n")
+
+
 
     # Check for a any Assembly string
     if not config['general']['assembly']:

--- a/snakefile.py
+++ b/snakefile.py
@@ -61,33 +61,9 @@ PATHIN     = os.path.join(OUTDIR, "pigx_work/input/")           # location of th
 GENOMEFILE = config['locations']['genome-fasta']    # where the reference genome being mapped to is stored
 GENOMEPATH = os.path.dirname(GENOMEFILE) + "/"
 ASSEMBLY   = config['general']['assembly'] # version of the genome being mapped to
+CPGISLAND_BEDFILE = config['locations']['cpgIsland-bedfile']
+REFGENES_BEDFILE  = config['locations']['refGenes-bedfile']
 
-# FIXME: lookup and fetch now done in diffmethreport, but should they get their own rule ??
-## should we do fetching at all? would be maybe more stable if we require people to download themselves.
-WEBFETCH = TrueOrFalse(config['general']['differential-methylation']['annotation']['webfetch'])
-CPGISLAND_BEDFILE = config['general']['differential-methylation']['annotation']['cpgIsland-bedfile']
-REFGENES_BEDFILE  = config['general']['differential-methylation']['annotation']['refGenes-bedfile']
-
-if CPGISLAND_BEDFILE and os.path.isfile(CPGISLAND_BEDFILE):
-  # make path absolute
-  CPGISLAND_BEDFILE = os.path.abspath(CPGISLAND_BEDFILE)
-  
-elif WEBFETCH:
-    CPGISLAND_BEDFILE = os.path.join(OUTDIR, 'pigx_work','refGenome',"cpgIslandExt."+ASSEMBLY+".bed.gz")
-    print("WARNING: Parameter 'general::differential-methylation::annotation::cpgIsland-bedfile' was not set to a valid file.\n",
-    "Updating to "+CPGISLAND_BEDFILE+" since webfetch was set.\n")
-    
-
-if REFGENES_BEDFILE and os.path.isfile(REFGENES_BEDFILE):
-  # make path absolute
-  REFGENES_BEDFILE = os.path.abspath(REFGENES_BEDFILE)
-  
-elif WEBFETCH:
-  REFGENES_BEDFILE = os.path.join(OUTDIR, 'pigx_work','refGenome',"knownGene."+ASSEMBLY+".bed.gz")
-  print("WARNING: Parameter 'general::differential-methylation::annotation::refGenes-bedfile' was not set to a valid file.\n",
-  "Updating to "+REFGENES_BEDFILE+" since webfetch was set.\n")
-  
-  
 
 #--- CHOOSE PIPELINE BRANCH
 USEBWAMETH = TrueOrFalse(config['general']['use_bwameth'])
@@ -364,7 +340,6 @@ rule final_report:
         methSegPng                   = os.path.join(DIR_seg,"{prefix}_{context}_{tool}.meth_segments.png"),
         scripts_dir                  = DIR_scripts,
         refGene_bedfile              = REFGENES_BEDFILE,
-        webfetch                     = WEBFETCH,
         # required for any report
         bibTexFile                   = BIBTEXPATH,
         prefix                       = "{prefix}_{context}_{tool}_{assembly}_{tool}",
@@ -404,7 +379,6 @@ rule final_report:
                                '"scripts_dir":"{params.scripts_dir}"',
                                
                                '"refGenes_bedfile":"{params.refGene_bedfile}"',
-                               '"webfetch":"{params.webfetch}"'
                            ])+"}}'",
                            "--logFile={log}"], "{log}", 
                            "echo '' ")

--- a/tests/settings.yaml
+++ b/tests/settings.yaml
@@ -17,8 +17,6 @@ general:
   differential-methylation:
     cores: 1
     qvalue: 0.05
-    annotation:
-      webfetch: no
 
 DManalyses:
   # The names of analyses can be anything but they have to be unique

--- a/tests/settings.yaml
+++ b/tests/settings.yaml
@@ -2,6 +2,8 @@ locations:
   input-dir: in/
   output-dir: out/
   genome-fasta: genome/sample.fasta
+  cpgIsland-bedfile: genome/cpgIslandExt.hg19.bed.gz
+  refGenes-bedfile: genome/refGene.hg19.bed.gz
 
 general:
   assembly: hg19
@@ -16,9 +18,7 @@ general:
     cores: 1
     qvalue: 0.05
     annotation:
-      cpgIsland-bedfile: pigx_work/refGenome/cpgIslandExt.hg19.bed.gz 
-      refGenes-bedfile: pigx_work/refGenome/refGene.hg19.bed.gz
-      webfetch:   no
+      webfetch: no
 
 DManalyses:
   # The names of analyses can be anything but they have to be unique


### PR DESCRIPTION
Clean up reports and associated scripts. 
Remove the webfetch option to download annotation files. Users should provide them beforehand. 
