### PR TITLE
Fix ggbio/ggplot2 incompatibility and GenomeInfoDb import

### DIFF
--- a/report_templates/diffmeth.Rmd.in
+++ b/report_templates/diffmeth.Rmd.in
@@ -73,6 +73,7 @@ knitr::opts_knit$set(progress = FALSE)
 
 ## load libraries
 library("methylKit")
+library("GenomeInfoDb")
 library("DT")
 library("genomation")
 library("rtracklayer")

--- a/scripts/ideoDMC.R
+++ b/scripts/ideoDMC.R
@@ -155,11 +155,11 @@ ideoDMC_hyper_hypo <- function(hyper, hypo, chrom.length,
     #                                                                                                  hypo.col)) + labs(title = title)
     # new alternative commented out
     d = c(g.per, g.po)
-    p = autoplot(myIdeo, layout = "karyogram")
+    p <- ggplot() + layout_karyogram(myIdeo, cytoband = FALSE)
     p + layout_karyogram(d, geom = "point", size = 0.65,
-                         aes(x = start,  y = meth.diff, color = id))+
-      scale_colour_manual("", values = c(hyper.col, hypo.col))+
-      labs(title = title) 
+                         aes(x = start, y = meth.diff, color = id)) +
+      scale_colour_manual("", values = c(hyper.col, hypo.col)) +
+      labs(title = title)
   }
 }
 


### PR DESCRIPTION
## Summary

- Fix `ggbio::autoplot()` karyogram call in `scripts/ideoDMC.R` that fails with newer `ggplot2` due to `GGbio` S4 class validation; replaced with `ggplot() + layout_karyogram()`
- Add explicit `library("GenomeInfoDb")` to `report_templates/diffmeth.Rmd.in` to avoid namespace errors when `keepStandardChromosomes()` is called

## Test plan

- [x] Full test suite passes (132/132 steps) on `fix-ggbio-compat` branch in a clean worktree
- [x] `diffmeth_report` jobs complete without error
- [x] Karyogram ideogram plots render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)